### PR TITLE
Fix build errors on ubuntu16.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,11 @@ if(WIN32)
     -o ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.o)
 endif (WIN32)
 
+if(UNIX AND NOT APPLE)
+# Qt states "must build your code with position independent code if Qt was built with -reduce-relocations"
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+endif()
+
 # Some in-house CMake functions/macros
 include(${CMAKE_SOURCE_DIR}/cmake/utils.cmake)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -179,8 +179,8 @@ if(UNIX AND NOT APPLE)
        INSTALL_LIBRARY_AND_SYMLINKS("${ST_QT_LOC}" lib)
      endforeach()
 
-    # Qt 5.5 needs ICU libaries in Linux 54
-    set(ICU_VERSION "54.1")
+    # Qt 5.7 needs ICU libraries in Linux
+    set(ICU_VERSION "56.1")
     foreach(ICU_LIB icuuc icui18n icudata)
       find_library(loc${ICU_LIB} lib${ICU_LIB}.so.${ICU_VERSION} NO_CMAKE_SYSTEM_PATH)
       if (NOT loc${ICU_LIB})


### PR DESCRIPTION
Small fixes to fix build errors on Ubuntu 16.04.
The built executable STViewer started fine.